### PR TITLE
Moved StreamQualityIndex under Playback category

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,6 +3,7 @@
   <category label="Playback">
   	 <setting id="StreamQuality" type="enum" label="30460" default="0" lvalues="30470|30480|30490" />
   	 <setting id="BitrateLimit" type="number" label="30540" default="10000" />
+  	 <setting id="StreamQualityIndex" type="number" default="-1" label="30520" />
   </category>
   <category label="Days (Legacy)">
     <setting type="sep" />
@@ -17,7 +18,5 @@
       <setting id="ShowLegacyMenu" type="bool" label="30530" default="false" />
   	  <setting id="ClearData" type="bool" label="30170" default="false" />
   	  <setting id="DisableSSL" type="bool" label="30180" default="false" />
-  	  <setting id="StreamQualityIndex" type="number" default="-1" label="30520" />
   </category>
-
 </settings>


### PR DESCRIPTION
Just wanted to suggest that this might be more suited under Playback and will help organize a wiki with all streaming & playback information in one place. 